### PR TITLE
eager loading

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).all.order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [n+1 query problem](https://github.com/GeorgeMarcus/golfr_backend/issues/1)

I resolved the n + 1 queries problem by replacing the lazy association of the users to the scores with an eager one.

**Before**

<img width="830" alt="Before(lazy)" src="https://user-images.githubusercontent.com/56991417/172412281-ad0d2184-1542-4af2-a22b-51773912ddc6.png">

**After**

<img width="855" alt="After(eager)" src="https://user-images.githubusercontent.com/56991417/172412336-5572fd00-ded4-42b3-92b5-e0b5a80cd7a4.png">

