### PR TITLE
limited the number of scores

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.limit(25).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -42,8 +42,6 @@ describe Api::ScoresController, type: :request do
     end
   end
 
-
-
   describe 'POST create' do
     it 'should save and return the new score if valid parameters' do
       score_count = Score.count

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -9,6 +9,10 @@ describe Api::ScoresController, type: :request do
     @score1 = create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
     @score2 = create(:score, user: user2, total_score: 99, played_at: '2021-06-20')
     @score3 = create(:score, user: user2, total_score: 68, played_at: '2021-06-13')
+
+    25.times do
+      create(:score, user: user2, total_score: 68, played_at: '2000-06-13')
+    end
   end
 
   describe 'GET feed' do
@@ -19,14 +23,26 @@ describe Api::ScoresController, type: :request do
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
 
-      expect(scores.size).to eq 3
+      expect(scores.size).to eq 25
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99
       expect(scores[0]['played_at']).to eq '2021-06-20'
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should allow only 25 scores to appear' do
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+    end
   end
+
+
 
   describe 'POST create' do
     it 'should save and return the new score if valid parameters' do


### PR DESCRIPTION
Fixes: [limit to 25](https://github.com/GeorgeMarcus/golfr_backend/issues/21)

**Changes**
Added a method to limit the array of scores to the first 25 scores and added a test to add this new feature.

**Before**
<img width="920" alt="Screenshot 2022-06-09 at 11 43 37" src="https://user-images.githubusercontent.com/56991417/172805231-86527c96-4f7b-400e-8584-2be76474dfeb.png">


**After**
<img width="493" alt="Screenshot 2022-06-09 at 11 45 14" src="https://user-images.githubusercontent.com/56991417/172805337-a5a35479-bac5-4ef9-996c-b76c3a37e7a5.png">

